### PR TITLE
feat(lltz michelson): type helpers

### DIFF
--- a/lib/lltz_michelson/type.ml
+++ b/lib/lltz_michelson/type.ml
@@ -6,6 +6,7 @@ module T = M.Type
 open T
 
 let tuple types =
+  (* Right-comb encoding of tuple-types *)
   match types with
   | [] -> unit
   | [ type_ ] -> type_

--- a/lib/lltz_michelson/type.ml
+++ b/lib/lltz_michelson/type.ml
@@ -11,3 +11,13 @@ let tuple types =
   | [ type_ ] -> type_
   | types -> pair types
 ;;
+
+let ors types =
+  (* Right-comb encoding of or-types (not efficient, but cheap) *)
+  let rec loop = function
+    | [] | [ _ ] -> assert false
+    | [ type1; type2 ] -> or_ type1 type2
+    | type_ :: types -> or_ type_ (loop types)
+  in
+  loop types
+;;

--- a/lib/lltz_michelson/type.ml
+++ b/lib/lltz_michelson/type.ml
@@ -1,0 +1,13 @@
+include Core
+
+module M = Michelson.Ast 
+module T = M.Type
+
+open T
+
+let tuple types =
+  match types with
+  | [] -> unit
+  | [ type_ ] -> type_
+  | types -> pair types
+;;

--- a/lib/lltz_michelson/type.ml
+++ b/lib/lltz_michelson/type.ml
@@ -1,24 +1,20 @@
-include Core
-
 module M = Michelson.Ast 
 module T = M.Type
-
-open T
 
 let tuple types =
   (* Right-comb encoding of tuple-types *)
   match types with
-  | [] -> unit
+  | [] -> T.unit
   | [ type_ ] -> type_
-  | types -> pair types
+  | types -> T.pair types
 ;;
 
 let ors types =
   (* Right-comb encoding of or-types (not efficient, but cheap) *)
   let rec loop = function
     | [] | [ _ ] -> assert false
-    | [ type1; type2 ] -> or_ type1 type2
-    | type_ :: types -> or_ type_ (loop types)
+    | [ type1; type2 ] -> T.or_ type1 type2
+    | type_ :: types -> T.or_ type_ (loop types)
   in
   loop types
 ;;


### PR DESCRIPTION
# Context:
https://app.asana.com/0/1207308081067689/1208023639799542
https://app.asana.com/0/1207308081067689/1208023639799543

# Description
This PR adds helper functions for creating tuple types and or types in Michelson.

# Manual testing
```dune build```

