### PR TITLE
feat(lltz): distinguishing two different types of concats

### DIFF
--- a/lib/lltz_ir/ast_builder.ml
+++ b/lib/lltz_ir/ast_builder.ml
@@ -895,19 +895,17 @@ module Default = struct
     create ~range (LLTZ.E.Prim (LLTZ.P.Cons, [ head; tail ])) tail.LLTZ.E.type_
   ;;
 
-  let concat1 ~range val1 str2 =
-    create
-      ~range
-      (LLTZ.E.Prim (LLTZ.P.Concat1, [ val1; str2 ]))
-      (mk_type ~range LLTZ.T.String)
-  ;;
+  let concat1 ~range val_list =
+    create ~range (LLTZ.E.Prim (LLTZ.P.Concat1, [val_list]))
+      (
+        match val_list.LLTZ.E.type_.LLTZ.T.desc with
+         | LLTZ.T.List ty -> ty
+         | _ -> raise_s [%message "Expected list or bytes type"]
+      )
 
-  let concat2 ~range val1 bytes2 =
-    create
-      ~range
-      (LLTZ.E.Prim (LLTZ.P.Concat2, [ val1; bytes2 ]))
-      (mk_type ~range LLTZ.T.Bytes)
-  ;;
+  let concat2 ~range val1 val2 =
+    create ~range (LLTZ.E.Prim (LLTZ.P.Concat2, [val1; val2]))
+      val1.LLTZ.E.type_
 
   let get ~range key collection =
     create
@@ -1269,8 +1267,8 @@ module With_dummy = struct
   let and_ lhs rhs = Default.and_ ~range:v lhs rhs
   let or_ lhs rhs = Default.or_ ~range:v lhs rhs
   let cons head tail = Default.cons ~range:v head tail
-  let concat1 val1 str2 = Default.concat1 ~range:v val1 str2
-  let concat2 val1 bytes2 = Default.concat2 ~range:v val1 bytes2
+  let concat1 val_list = Default.concat1 ~range:v val_list
+  let concat2 val1 val2 = Default.concat2 ~range:v val1 val2
   let get key collection = Default.get ~range:v key collection
   let mem key collection = Default.mem ~range:v key collection
   let exec value lambda = Default.exec ~range:v value lambda

--- a/lib/michelson/ast.ml
+++ b/lib/michelson/ast.ml
@@ -48,7 +48,9 @@ module Prim = struct
       | Chain_id
       | Check_signature
       | Compare
-      | Concat
+      | Concat1
+      | Concat2
+      | Concat_unresolved
       | Cons
       | Create_account
       | Create_contract
@@ -159,7 +161,9 @@ module Prim = struct
       | Chain_id -> "CHAIN_ID"
       | Check_signature -> "CHECK_SIGNATURE"
       | Compare -> "COMPARE"
-      | Concat -> "CONCAT"
+      | Concat1 -> "CONCAT1"
+      | Concat2 -> "CONCAT2"
+      | Concat_unresolved -> "CONCAT"
       | Cons -> "CONS"
       | Create_account -> "CREATE_ACCOUNT"
       | Create_contract -> "CREATE_CONTRACT"
@@ -270,7 +274,9 @@ module Prim = struct
       | "CHAIN_ID" -> Chain_id
       | "CHECK_SIGNATURE" -> Check_signature
       | "COMPARE" -> Compare
-      | "CONCAT" -> Concat
+      | "CONCAT1" -> Concat1
+      | "CONCAT2" -> Concat2
+      | "CONCAT" -> Concat_unresolved
       | "CONS" -> Cons
       | "CREATE_ACCOUNT" -> Create_account
       | "CREATE_CONTRACT" -> Create_contract
@@ -718,7 +724,8 @@ module Instruction = struct
   let chain_id = prim (I Chain_id)
   let check_signature = prim (I Check_signature)
   let compare = prim (I Compare)
-  let concat = prim (I Concat)
+  let concat1 = prim (I Concat1)
+  let concat2 = prim (I Concat2)
   let cons = prim (I Cons)
 
   let contract ?(annot = None) ty =

--- a/test/test_all_vars.ml
+++ b/test/test_all_vars.ml
@@ -415,7 +415,7 @@ let%expect_test "vars map referencing outer var inside lam" =
            ~map:
              { lam_var = var "v", string_ty
              ; body =
-                 concat1 (variable (var "v") string_ty) (variable (var "outer") string_ty)
+                 concat2 (variable (var "v") string_ty) (variable (var "outer") string_ty)
              })
   in
   print_vars expr;

--- a/test/test_free_vars.ml
+++ b/test/test_free_vars.ml
@@ -632,7 +632,7 @@ let%expect_test "fv map overshadowing var (no free var)" =
            ~map:
              { lam_var = var "s", string_ty
              ; body =
-                 concat1 (variable (var "s") string_ty) (variable (var "s") string_ty)
+                 concat2 (variable (var "s") string_ty) (variable (var "s") string_ty)
              })
   in
   print_free_vars expr;


### PR DESCRIPTION
# Description
Michelson has two different types of CONCAT instruction one of arity 1 and one of arity 2, yet they both have the same name. Previously we didn't distinguish between them and LLTZ always used CONCAT of arity 1, generating first a list of elements and then concatenating even when we could use concat of arity 2 directly. In this PR we distinguih between these two different CONCAT types and thus reduce the code size. There are now only four remaining expect tests where the code size is slightly larger (TBD).

# Manual testing
from ligo (warnings fix branch) with this change as a submodule:
- set lltz in raw options to true
- replace "if options.backend.lltz_ir" -> "if true" in both cases in of_mini_c.ml
dune runtest -j 1

(only 4 tests now have a flag that codesize without lltz can be slightly smaller.)
