### PR TITLE
feat(lltz): fixing codesize differences

### DIFF
--- a/lib/michelson/optimisations/oasis_core/michelson_rewriter.ml
+++ b/lib/michelson/optimisations/oasis_core/michelson_rewriter.ml
@@ -1046,9 +1046,10 @@ let lltz_specific (expr : instr_list) : (instr_list * instr_list) option =
     [push_instr t x; MI1 Some_] $ rest
   | MIpush ({mt = MT1 (Option, t)}, {literal = None_}) :: rest ->
     [MI0 (None_ t)] $ rest
-  (*push list*)
+  (* Create list directly using NIL and CONS if it has just one element, instead of PUSH list ... *)
   | MIpush ({mt = MT1 (List, t)}, {literal = Seq xs}) :: rest when List.length xs = 1 ->
     [MI0 (Nil t)] @ List.concat (List.map ~f:(fun x -> [push_instr t x; MI2 Cons] ) (List.rev xs)) $ rest
+  (* LAMBDA int int { constant "hash..."} -> PUSH (lambda int int) (constant "hash...") *)
   | MIlambda ({mt = MT0 Int}, {mt = MT0 Int}, {instr = MIConstant {literal = String hash}}) :: rest ->
     [MIpush (mt_lambda mt_int mt_int, MLiteral.constant hash)] $ rest
   | MIpush ({mt = MT2 (Or {annot_left; annot_right}, tl, tr)}, {literal = Left x}) :: rest ->

--- a/lib/michelson/optimisations/oasis_core/michelson_rewriter.ml
+++ b/lib/michelson/optimisations/oasis_core/michelson_rewriter.ml
@@ -1042,15 +1042,19 @@ let lltz_specific (expr : instr_list) : (instr_list * instr_list) option =
   match expr with
   (*| MIpush (t, l) :: MI1 Some_ :: rest ->
     [MIpush (mt_option t, MLiteral.some l)] $ rest*)
-  | MIpush ({ mt = MT1 (Option, t) }, { literal = Some_ x }) :: rest ->
-    [ push_instr t x; MI1 Some_ ] $ rest
-  | MIpush ({ mt = MT1 (Option, t) }, { literal = None_ }) :: rest ->
-    [ MI0 (None_ t) ] $ rest
-  | MIpush ({ mt = MT2 (Or { annot_left; annot_right }, tl, tr) }, { literal = Left x })
-    :: rest -> [ push_instr tl x; MI1 (Left (annot_left, annot_right, tr)) ] $ rest
-  | MIpush ({ mt = MT2 (Or { annot_left; annot_right }, tl, tr) }, { literal = Right x })
-    :: rest ->
-    [ push_instr tr x; MI1 (Right (annot_left, annot_right, tl)) ] $ rest
+  | MIpush ({mt = MT1 (Option, t)}, {literal = Some_ x}) :: rest ->
+    [push_instr t x; MI1 Some_] $ rest
+  | MIpush ({mt = MT1 (Option, t)}, {literal = None_}) :: rest ->
+    [MI0 (None_ t)] $ rest
+  (*push list*)
+  | MIpush ({mt = MT1 (List, t)}, {literal = Seq xs}) :: rest when List.length xs = 1 ->
+    [MI0 (Nil t)] @ List.concat (List.map ~f:(fun x -> [push_instr t x; MI2 Cons] ) (List.rev xs)) $ rest
+  | MIlambda ({mt = MT0 Int}, {mt = MT0 Int}, {instr = MIConstant {literal = String hash}}) :: rest ->
+    [MIpush (mt_lambda mt_int mt_int, MLiteral.constant hash)] $ rest
+  | MIpush ({mt = MT2 (Or {annot_left; annot_right}, tl, tr)}, {literal = Left x}) :: rest ->
+    [push_instr tl x; MI1 (Left (annot_left, annot_right, tr))] $ rest
+  | MIpush ({mt = MT2 (Or {annot_left; annot_right}, tl, tr)}, {literal = Right x}) :: rest ->
+    [push_instr tr x; MI1 (Right (annot_left, annot_right, tl))] $ rest
     (*| MIpush (t2, l2)
       :: MIpush (t1, l1)
       :: MI2 (Pair (annot_fst, annot_snd))

--- a/test/test_last_vars.ml
+++ b/test/test_last_vars.ml
@@ -2456,7 +2456,7 @@ let%expect_test "test_if_cons" =
         { SWAP ; DROP ; DROP ; PUSH int 999 } }
 
     Optimised:
-    { PUSH (list nat) { 0 } ; IF_CONS { ADD } { PUSH int 999 } } |}]
+    { NIL nat ; PUSH nat 0 ; CONS ; IF_CONS { ADD } { PUSH int 999 } } |}]
 
 (*
   if_left overshadow lam_var in left or right:

--- a/test/test_nodes.ml
+++ b/test/test_nodes.ml
@@ -3107,7 +3107,11 @@ let%expect_test "pairing_check bls12 list" =
       PAIRING_CHECK }
 
     Optimised:
-    { PUSH (list (pair bls12_381_g1 bls12_381_g2)) { Pair 0x4731 0x4732 } ;
+    { NIL (pair bls12_381_g1 bls12_381_g2) ;
+      PUSH bls12_381_g2 0x4732 ;
+      PUSH bls12_381_g1 0x4731 ;
+      PAIR ;
+      CONS ;
       PAIRING_CHECK } |}]
 
 let%expect_test "voting_power key_hash" =


### PR DESCRIPTION
# Description
This PR, together with one other on the ligo side, fixes the remaining small cases of codesize increase on all LIGO tests. 

# Manual testing
In LIGO:
dune runtest -j 1