### PR TITLE
feat(lltz): added IS_IMPLICIT_ACCOUNT instruction

### DIFF
--- a/lib/lltz_codegen/lltz_codegen.ml
+++ b/lib/lltz_codegen/lltz_codegen.ml
@@ -184,6 +184,7 @@ let convert_primitive (prim : LLTZ.P.t) : Michelson.Ast.t =
   | Size -> size
   | Address -> address
   | Implicit_account -> implicit_account
+  | Is_implicit_account -> is_implicit_account
   | Contract (annot, ty) -> contract ~annot (convert_type ty)
   | Pack -> pack
   | Unpack ty -> unpack (convert_type ty)

--- a/lib/lltz_ir/ast_builder.ml
+++ b/lib/lltz_ir/ast_builder.ml
@@ -578,6 +578,13 @@ module Default = struct
       (mk_type ~range (LLTZ.T.Contract (mk_type ~range LLTZ.T.Unit)))
   ;;
 
+  let is_implicit_account ~range address =
+    create
+      ~range
+      (LLTZ.E.Prim (LLTZ.P.Is_implicit_account, [ address ]))
+      (mk_type ~range (LLTZ.T.Option (mk_type ~range LLTZ.T.Key_hash)))
+  ;;
+
   let contract ~range (opt, ty) address =
     create
       ~range
@@ -1234,6 +1241,7 @@ module With_dummy = struct
   let size container = Default.size ~range:v container
   let address contract = Default.address ~range:v contract
   let implicit_account key_hash = Default.implicit_account ~range:v key_hash
+  let is_implicit_account address = Default.is_implicit_account ~range:v address
   let contract (opt, ty) address = Default.contract ~range:v (opt, ty) address
   let pack value = Default.pack ~range:v value
   let unpack ty value = Default.unpack ~range:v ty value

--- a/lib/lltz_ir/primitive.ml
+++ b/lib/lltz_ir/primitive.ml
@@ -43,6 +43,7 @@ type t =
   | Size
   | Address
   | Implicit_account
+  | Is_implicit_account
   | Contract of string option * Type.t
   | Pack
   | Unpack of Type.t

--- a/lib/lltz_michelson/lltz_michelson.ml
+++ b/lib/lltz_michelson/lltz_michelson.ml
@@ -155,6 +155,7 @@ let convert_primitive (prim : LLTZ.P.t) : Michelson.Ast.t =
   | Size -> size
   | Address -> address
   | Implicit_account -> implicit_account
+  | Is_implicit_account -> is_implicit_account
   | Contract (opt, ty) -> contract (convert_type ty) (* TODO: resolve tag option*)
   | Pack -> pack
   | Unpack ty -> unpack (convert_type ty)

--- a/lib/michelson/ast.ml
+++ b/lib/michelson/ast.ml
@@ -55,6 +55,7 @@ module Prim = struct
       | Create_account
       | Create_contract
       | Implicit_account
+      | Is_implicit_account
       | Dip
       | Drop
       | Dup
@@ -168,6 +169,7 @@ module Prim = struct
       | Create_account -> "CREATE_ACCOUNT"
       | Create_contract -> "CREATE_CONTRACT"
       | Implicit_account -> "IMPLICIT_ACCOUNT"
+      | Is_implicit_account -> "IS_IMPLICIT_ACCOUNT"
       | Dip -> "DIP"
       | Drop -> "DROP"
       | Dup -> "DUP"
@@ -281,6 +283,7 @@ module Prim = struct
       | "CREATE_ACCOUNT" -> Create_account
       | "CREATE_CONTRACT" -> Create_contract
       | "IMPLICIT_ACCOUNT" -> Implicit_account
+      | "IS_IMPLICIT_ACCOUNT" -> Is_implicit_account
       | "DIP" -> Dip
       | "DROP" -> Drop
       | "DUP" -> Dup
@@ -781,6 +784,7 @@ module Instruction = struct
   let if_left ~then_ ~else_ = prim ~arguments:[ seq then_; seq else_ ] (I If_left)
   let if_none ~then_ ~else_ = prim ~arguments:[ seq then_; seq else_ ] (I If_none)
   let implicit_account = prim (I Implicit_account)
+  let is_implicit_account = prim (I Is_implicit_account)
   let is_nat = prim (I Is_nat)
   let iter instrs = prim ~arguments:[ seq instrs ] (I Iter)
   let join_tickets = prim (I Join_tickets)

--- a/lib/michelson/optimisations/if_suffix_rewriter.ml
+++ b/lib/michelson/optimisations/if_suffix_rewriter.ml
@@ -27,6 +27,7 @@ let is_injective : string -> bool = function
   | "CHECK_SIGNATURE"
   | "CONS"
   | "IMPLICIT_ACCOUNT"
+  | "IS_IMPLICIT_ACCOUNT"
   | "EMPTY_MAP"
   | "EMPTY_SET"
   | "HASH_KEY"

--- a/lib/michelson/optimisations/michelson_base/primitive.ml
+++ b/lib/michelson/optimisations/michelson_base/primitive.ml
@@ -45,6 +45,7 @@ type 'ty prim1 =
   | Size
   | Address
   | Implicit_account
+  | Is_implicit_account
   | Contract of string option * 'ty
   | Pack
   | Unpack of 'ty

--- a/lib/michelson/optimisations/michelson_base/primitive.mli
+++ b/lib/michelson/optimisations/michelson_base/primitive.mli
@@ -46,6 +46,7 @@ type 'ty prim1 =
   | Size (** Size / Length.*)
   | Address (** Address of a contract.*)
   | Implicit_account (** Implicit Account of a key_hash.*)
+  | Is_implicit_account (** Is_implicit Account of an address.*)
   | Contract of string option * 'ty (** Contract of an address and entrypoint.*)
   | Pack (** Packing values.*)
   | Unpack of 'ty (** Unpacking values.*)

--- a/lib/michelson/optimisations/michelson_base/typing.ml
+++ b/lib/michelson/optimisations/michelson_base/typing.ml
@@ -107,6 +107,7 @@ let type_prim1 = function
   | Size
   | Address
   | Implicit_account
+  | Is_implicit_account
   | Pack
   | Set_delegate
   | Read_ticket

--- a/lib/michelson/optimisations/oasis_core/michelson.ml
+++ b/lib/michelson/optimisations/oasis_core/michelson.ml
@@ -1416,6 +1416,12 @@ let mi_implicit_account =
     | _ -> None)
 ;;
 
+let mi_is_implicit_account =
+  mk_spec_basic "IS_IMPLICIT_ACCOUNT" ~arities:(1, 1) (function
+    | { mt = MT0 Address; _ } :: _ -> Some [ mt_option mt_key_hash ]
+    | _ -> None)
+;;
+
 let mi_voting_power =
   mk_spec_basic "VOTING_POWER" ~arities:(1, 1) (function
     | { mt = MT0 Key_hash; _ } :: _ -> Some [ mt_nat ]
@@ -1516,6 +1522,7 @@ let spec_of_prim1 p =
   | Getn n -> mi_getn n
   | Address -> mi_address
   | Implicit_account -> mi_implicit_account
+  | Is_implicit_account -> mi_is_implicit_account
   | Voting_power -> mi_voting_power
   | Size -> mi_size
   | Car | Cdr -> assert false
@@ -1703,6 +1710,7 @@ let name_of_instr_exn = function
         | Size
         | Address
         | Implicit_account
+        | Is_implicit_account
         | Contract _
         | Pack
         | Unpack _
@@ -2125,6 +2133,7 @@ module Of_micheline = struct
          | "ADDRESS", [] -> MI1 Address
          | "SELF_ADDRESS", [] -> MI0 Self_address
          | "IMPLICIT_ACCOUNT", [] -> MI1 Implicit_account
+         | "IS_IMPLICIT_ACCOUNT", [] -> MI1 Is_implicit_account
          | "TRANSFER_TOKENS", [] -> MI3 Transfer_tokens
          | "CHECK_SIGNATURE", [] -> MI3 Check_signature
          | "SET_DELEGATE", [] -> MI1 Set_delegate
@@ -2486,6 +2495,7 @@ module To_micheline = struct
           | Size
           | Address
           | Implicit_account
+          | Is_implicit_account
           | Pack
           | Hash_key
           | Blake2b

--- a/lib/michelson/optimisations/oasis_core/michelson_rewriter.ml
+++ b/lib/michelson/optimisations/oasis_core/michelson_rewriter.ml
@@ -166,6 +166,7 @@ let rec may_fail = function
       | Size
       | Address
       | Implicit_account
+      | Is_implicit_account
       | Pack
       | Hash_key
       | Blake2b

--- a/test/test_nodes.ml
+++ b/test/test_nodes.ml
@@ -2921,6 +2921,18 @@ let%expect_test "implicit_account key_hash" =
 
     Optimised:
     { PUSH key_hash "tz1ABC123" ; IMPLICIT_ACCOUNT } |}]
+;;
+
+let%expect_test "is_implicit_account address" =
+  let e = is_implicit_account (address_const "tz1ABC123") in
+  test_expr e;
+  [%expect
+    {|
+    { PUSH address "tz1ABC123" ; IS_IMPLICIT_ACCOUNT }
+
+    Optimised:
+    { PUSH address "tz1ABC123" ; IS_IMPLICIT_ACCOUNT } |}]
+;;
 
 let%expect_test "contract opt (bool_ty) address" =
   let e = contract (None, bool_ty) (address_const "KT1XYZ") in


### PR DESCRIPTION
IS_IMPLICIT_ACCOUNT for the SEOUL upgrade.

Question:
* LLTZ doesnt have a concept of "only for protocol >= XXX" does it?